### PR TITLE
Add Cameron Page Stub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,6 +1403,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 name = "vanhouzen-site"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
  "axum-htmx",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.98"
 axum = "0.8"
 axum-htmx = "0.7"
 dotenvy = "0.15"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
 services:
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    build: .
+    develop:
+      watch:
+        - action: rebuild
+          path: .
     ports:
       - "8080:8080"
     environment:
@@ -22,7 +24,7 @@ services:
       - "4317:4317"
       - "4318:4318"
     environment:
-      - LOG_LEVEL=debug
+      - LOG_LEVEL=info
     healthcheck:
       test: ["CMD", "wget", "--spider", "http://localhost:16686"]
       interval: 10s

--- a/src/cameron.rs
+++ b/src/cameron.rs
@@ -1,12 +1,11 @@
 use axum::{response::IntoResponse, routing::get};
-use maud::html;
-
-use crate::layout;
+use maud::{DOCTYPE, Markup, html};
 
 pub fn router() -> axum::Router {
     axum::Router::new().route("/", get(cameron))
 }
 
+#[fastrace::trace]
 async fn cameron() -> impl IntoResponse {
     let content = html!(
         main {
@@ -16,4 +15,35 @@ async fn cameron() -> impl IntoResponse {
         }
     );
     layout("Cameron", content)
+}
+
+#[fastrace::trace]
+fn layout(title: &str, content: maud::Markup) -> Markup {
+    html!(
+        (DOCTYPE)
+        html {
+            head {
+                title { (title) }
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                link rel="stylesheet" href="/assets/pico.min.css";
+                link rel="stylesheet" href="/assets/style.css";
+            }
+            body {
+                header {
+                    nav {
+                        ul {
+                            li { a href="/" { "Home" } }
+                            li { a href="/about" { "About" } }
+                            li { a href="/projects" { "Projects" } }
+                        }
+                    }
+                }
+            }
+            main {(content)}
+            footer {
+                p { "Copyright © 2025 Cameron VanHouzen" }
+            }
+        }
+    )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,29 +31,10 @@ async fn main() {
     // Setup logging out to the console
     logforth::stdout().apply();
 
-    let otlp_exporter_endpoint =
-        std::env::var("OTLP_EXPORTER_ENDPOINT").expect("OTLP_EXPORTER_ENDPOINT must be defined");
-
-    // Initialize reporter
-    let reporter = OpenTelemetryReporter::new(
-        SpanExporter::builder()
-            .with_tonic()
-            .with_endpoint(otlp_exporter_endpoint)
-            .with_protocol(opentelemetry_otlp::Protocol::Grpc)
-            .with_timeout(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT)
-            .build()
-            .expect("initialize oltp exporter"),
-        SpanKind::Server,
-        Cow::Owned(
-            Resource::builder()
-                .with_attributes([KeyValue::new("service.name", "vanhouzen-site")])
-                .build(),
-        ),
-        InstrumentationScope::builder("vanhouzen-site")
-            .with_version(env!("CARGO_PKG_VERSION"))
-            .build(),
-    );
-    fastrace::set_reporter(reporter, Config::default());
+    // Initialize OTLP reporter
+    if let Ok(reporter) = initialize_otlp_reporter() {
+        fastrace::set_reporter(reporter, Config::default());
+    }
 
     let app = axum::Router::new()
         .nest_service("/assets", ServeDir::new("assets"))
@@ -77,6 +58,28 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 
     fastrace::flush();
+}
+
+fn initialize_otlp_reporter() -> Result<OpenTelemetryReporter, anyhow::Error> {
+    let otlp_exporter_endpoint = std::env::var("OTLP_EXPORTER_ENDPOINT")?;
+    let reporter = OpenTelemetryReporter::new(
+        SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(otlp_exporter_endpoint)
+            .with_protocol(opentelemetry_otlp::Protocol::Grpc)
+            .with_timeout(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT)
+            .build()?,
+        SpanKind::Server,
+        Cow::Owned(
+            Resource::builder()
+                .with_attributes([KeyValue::new("service.name", "vanhouzen-site")])
+                .build(),
+        ),
+        InstrumentationScope::builder("vanhouzen-site")
+            .with_version(env!("CARGO_PKG_VERSION"))
+            .build(),
+    );
+    Ok(reporter)
 }
 
 #[fastrace::trace]


### PR DESCRIPTION
This pull request introduces multiple changes across the codebase, focusing on improving observability, modularizing code, and enhancing the project's configuration. Key updates include the addition of a new dependency, refactoring of the OTLP reporter initialization, and updates to the `docker-compose.yml` file. Below is a detailed breakdown of the most important changes:

### Observability Improvements:
* Refactored the OTLP reporter initialization in `src/main.rs` by moving the logic into a new `initialize_otlp_reporter` function, improving modularity and error handling using the `anyhow` crate. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL34-R37) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR63-R84)
* Added `#[fastrace::trace]` attribute to the `cameron` and `layout` functions in `src/cameron.rs` to enable tracing for these functions. [[1]](diffhunk://#diff-49d5dfca1bce8c7e5d388ac95be4ea7bdf7a12a969a7ef0f12f5b8cd8a629741L2-R8) [[2]](diffhunk://#diff-49d5dfca1bce8c7e5d388ac95be4ea7bdf7a12a969a7ef0f12f5b8cd8a629741R19-R49)

### Dependency Management:
* Added the `anyhow` crate (version 1.0.98) to `Cargo.toml` for enhanced error handling.

### Configuration Enhancements:
* Updated `docker-compose.yml` to simplify the `build` configuration and introduce a `develop` section with a `watch` action for automatic rebuilds.
* Changed the `LOG_LEVEL` environment variable in `docker-compose.yml` from `debug` to `info` for less verbose logging in production.

### Code Simplification:
* Consolidated the `layout` function in `src/cameron.rs` to include the HTML structure for the application, reducing duplication and improving maintainability.