### PR TITLE
Switch to Hypertext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +506,31 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hypertext"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb73b82c6a76434fd87a0668ef3ff1a8182512dfb610eef9138169a7e2d3a0ed"
+dependencies = [
+ "axum-core",
+ "html-escape",
+ "hypertext-macros",
+ "itoa",
+ "ryu",
+]
+
+[[package]]
+name = "hypertext-macros"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c120534b9d41bd317a5b111aacc38a34071d15df9462c0e21f6093ade3a03660"
+dependencies = [
+ "html-escape",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -624,30 +658,6 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "maud"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
-dependencies = [
- "axum-core",
- "http",
- "itoa",
- "maud_macros",
-]
-
-[[package]]
-name = "maud_macros"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7261b00f3952f617899bc012e3dbd56e4f0110a038175929fa5d18e5a19913ca"
-dependencies = [
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "memchr"
@@ -884,18 +894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
 ]
 
 [[package]]
@@ -1400,6 +1398,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
 name = "vanhouzen-site"
 version = "0.1.0"
 dependencies = [
@@ -1410,9 +1414,9 @@ dependencies = [
  "fastrace",
  "fastrace-axum",
  "fastrace-opentelemetry",
+ "hypertext",
  "log",
  "logforth",
- "maud",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -1420,12 +1424,6 @@ dependencies = [
  "tower-http",
  "tower-livereload",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,24 +6,24 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0"
 axum = "0.8"
 axum-htmx = "0.7"
 dotenvy = "0.15"
 fastrace = { version = "0.7", features = ["enable"] }
 fastrace-axum = "0.1"
-fastrace-opentelemetry = "0.10.0"
+fastrace-opentelemetry = "0.10"
+hypertext = { version = "0.12", features = ["axum"] }
 log = "0.4"
-logforth = "0.24.0"
-maud = { version = "0.27", features = ["axum"] }
-opentelemetry = { version = "0.29.0", default-features = false, features = [
+logforth = "0.24"
+opentelemetry = { version = "0.29", default-features = false, features = [
     "trace",
 ] }
-opentelemetry-otlp = { version = "0.29.0", default-features = false, features = [
+opentelemetry-otlp = { version = "0.29", default-features = false, features = [
     "trace",
     "grpc-tonic",
 ] }
-opentelemetry_sdk = { version = "0.29.0", default-features = false, features = [
+opentelemetry_sdk = { version = "0.29", default-features = false, features = [
     "trace",
 ] }
 tokio = { version = "1.44", features = ["rt-multi-thread", "macros"] }

--- a/src/cameron.rs
+++ b/src/cameron.rs
@@ -1,5 +1,5 @@
 use axum::{response::IntoResponse, routing::get};
-use maud::{DOCTYPE, Markup, html};
+use hypertext::prelude::*;
 
 pub fn router() -> axum::Router {
     axum::Router::new().route("/", get(cameron))
@@ -7,10 +7,10 @@ pub fn router() -> axum::Router {
 
 #[fastrace::trace]
 async fn cameron() -> impl IntoResponse {
-    let content = html!(
+    let content = hypertext::maud!(
         main {
             h1 { "Cameron VanHouzen" }
-            img id="profile" src="/assets/images/party_cam.jpeg" alt="Cameron VanHouzen" {}
+            img id="profile" src="/assets/images/party_cam.jpeg" alt="Cameron VanHouzen";
             p { "Ayy yo its me Cameron, I do computer stuff like this website." }
         }
     );
@@ -18,9 +18,9 @@ async fn cameron() -> impl IntoResponse {
 }
 
 #[fastrace::trace]
-fn layout(title: &str, content: maud::Markup) -> Markup {
-    html!(
-        (DOCTYPE)
+fn layout(title: &str, content: impl hypertext::Renderable) -> impl axum::response::IntoResponse {
+    hypertext::maud!(
+        !DOCTYPE
         html {
             head {
                 title { (title) }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,29 +3,21 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
 };
 
-use axum::{
-    response::{IntoResponse, Redirect},
-    routing::get,
-};
-use dotenvy::dotenv;
+use axum::routing::get;
 use fastrace::collector::Config;
-use fastrace_axum::FastraceLayer;
 use fastrace_opentelemetry::OpenTelemetryReporter;
-use log::error;
-use maud::{DOCTYPE, Markup, html};
+use hypertext::prelude::*;
 use opentelemetry::{InstrumentationScope, KeyValue, trace::SpanKind};
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
 use opentelemetry_sdk::Resource;
-use tower_http::services::ServeDir;
-use tower_livereload::LiveReloadLayer;
 
 mod cameron;
 
 // Entrypoint for axum application
 #[tokio::main]
 async fn main() {
-    if let Err(error) = dotenv() {
-        error!("failed to load env file, error: {error}")
+    if let Err(error) = dotenvy::dotenv() {
+        log::error!("failed to load env file, error: {error}")
     }
 
     // Setup logging out to the console
@@ -37,14 +29,14 @@ async fn main() {
     }
 
     let app = axum::Router::new()
-        .nest_service("/assets", ServeDir::new("assets"))
+        .nest_service("/assets", tower_http::services::ServeDir::new("assets"))
         .nest("/cameron", cameron::router())
         .route("/", get(index))
-        .fallback(async || Redirect::to("/"))
-        .layer(FastraceLayer);
+        .fallback(async || axum::response::Redirect::to("/"))
+        .layer(fastrace_axum::FastraceLayer);
 
     #[cfg(debug_assertions)]
-    let app = app.layer(LiveReloadLayer::new());
+    let app = app.layer(tower_livereload::LiveReloadLayer::new());
 
     let port: u16 = std::env::var("PORT")
         .expect("PORT environment variable must be set")
@@ -62,7 +54,7 @@ async fn main() {
 
 fn initialize_otlp_reporter() -> Result<OpenTelemetryReporter, anyhow::Error> {
     let otlp_exporter_endpoint = std::env::var("OTLP_EXPORTER_ENDPOINT")?;
-    let reporter = OpenTelemetryReporter::new(
+    let reporter = fastrace_opentelemetry::OpenTelemetryReporter::new(
         SpanExporter::builder()
             .with_tonic()
             .with_endpoint(otlp_exporter_endpoint)
@@ -83,9 +75,9 @@ fn initialize_otlp_reporter() -> Result<OpenTelemetryReporter, anyhow::Error> {
 }
 
 #[fastrace::trace]
-fn layout(title: &str, content: Markup) -> Markup {
-    html! {
-        (DOCTYPE)
+fn layout(title: &str, content: impl hypertext::Renderable) -> impl axum::response::IntoResponse {
+    hypertext::maud! {
+        !DOCTYPE
         html {
             head {
                 title { (title) }
@@ -100,8 +92,8 @@ fn layout(title: &str, content: Markup) -> Markup {
 }
 
 #[fastrace::trace]
-async fn index() -> impl IntoResponse {
-    let content = html! {
+async fn index() -> impl axum::response::IntoResponse {
+    let content = hypertext::maud! {
         main {
             h1 { "Welcome to the VanHouzen Family!" }
             p { "This site houses the personal pages for the VanHouzen family and friends" }


### PR DESCRIPTION
This pull request updates dependencies and refactors the codebase to replace the `maud` templating engine with the new `hypertext` crate for HTML rendering. It also improves dependency versioning and cleans up imports and usage patterns for several libraries.

**Dependency and templating refactor:**

* Replaced `maud` with `hypertext` for HTML templating throughout the codebase, updating all usages and imports accordingly (`src/cameron.rs`, `src/main.rs`). [[1]](diffhunk://#diff-49d5dfca1bce8c7e5d388ac95be4ea7bdf7a12a969a7ef0f12f5b8cd8a629741L2-R23) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL6-R20) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL86-R80) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL103-R96)
* Added the `hypertext` dependency with `axum` feature, and removed the `maud` dependency from `Cargo.toml`.

**Dependency version updates and cleanup:**

* Updated several dependencies in `Cargo.toml` to use less restrictive or more consistent version numbers (e.g., `anyhow`, `fastrace-opentelemetry`, `logforth`, `opentelemetry`, etc.).
* Updated usage of `dotenv` to `dotenvy`, and improved error logging for environment loading in `main.rs`.

**Axum and middleware improvements:**

* Updated references to middleware and layers (e.g., `FastraceLayer`, `ServeDir`, `LiveReloadLayer`) to use direct crate paths instead of importing at the top, improving clarity and reducing import clutter.
* Updated the initialization of the OpenTelemetry reporter to use the fully qualified path for clarity.